### PR TITLE
Rebrand Spirent references to VIAVI in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# AWS Windows Spirent TestCenter Application Terraform
+# AWS Windows TestCenter Application Terraform
 
 ## Description
 
-Run a Windows Server instance and install the Windows Spirent TestCenter application.
-After the instance has been started connect using Remote Desktop to use Spirent TestCenter.
+Run a Windows Server instance and install the Windows TestCenter application.
+After the instance has been started connect using Remote Desktop to use TestCenter.
 
-[Spirent TestCenter Virtual](https://github.com/Spirent-terraform-Modules/terraform-aws-stcv)
+[TestCenter Virtual](https://github.com/Spirent-terraform-Modules/terraform-aws-stcv)
 traffic generator instances can be created via Terraform.
 
 ## Prerequisites
 
-- Obtain a copy of the Windows Spirent TestCenter Application from http://support.spirent.com.
+- Obtain a copy of the Windows TestCenter Application from [VIAVI support](https://support.viavisolutions.com/en-us/support/customer-support/technical-support).
 Be sure to update the `stc_installer` variable to point to this file.
 
 ## Connect to Windows Server
@@ -25,8 +25,8 @@ After the Windows Server instance is running, you can connect to it over Remote 
 6. Locate and launch the RDP file you downloaded in step 3.
 7. Click _Connect_ and provide the password from step 5.  The username is `Administrator`.
 8. You may receive a security warning about an insecure certificate due to the instance using a self-signed certificate.  Click _Yes_ to continue.
-9. You should now see the Windows desktop with a shortcut to the Spirent TestCenter Application.
-10. Launch the Spirent TestCenter Application.
+9. You should now see the Windows desktop with a shortcut to the TestCenter Application.
+10. Launch the TestCenter Application.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/examples/run-stc-gui-eip/README.md
+++ b/examples/run-stc-gui-eip/README.md
@@ -1,6 +1,6 @@
-## Run Windows Spirent TestCenter Application Using Elastic IPs
+## Run Windows TestCenter Application Using Elastic IPs
 
-Run a Windows Server 2019 instance using elastic IPs and install the Spirent TestCenter Application.
+Run a Windows Server 2019 instance using elastic IPs and install the TestCenter Application.
 
 ## Usage
 
@@ -14,7 +14,7 @@ This example will create resources that will incur a cost. Run `terraform destro
 
 The `terraform apply` will take approximately 30 minutes to complete in order to provision the Windows Server instance.
 
-[Connect](../../README.md#connect-to-windows-server) to the Windows Server instance via Remote Desktop and launch the Spirent TestCenter Application.
+[Connect](../../README.md#connect-to-windows-server) to the Windows Server instance via Remote Desktop and launch the TestCenter Application.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/examples/run-stc-gui/README.md
+++ b/examples/run-stc-gui/README.md
@@ -1,6 +1,6 @@
-## Run Windows Spirent TestCenter Application
+## Run Windows TestCenter Application
 
-Run a Windows Server 2019 instance and install the Spirent TestCenter Application.
+Run a Windows Server 2019 instance and install the TestCenter Application.
 
 ## Usage
 
@@ -14,7 +14,7 @@ This example will create resources that will incur a cost. Run `terraform destro
 
 The `terraform apply` will take approximately 30 minutes to complete in order to provision the Windows Server instance.
 
-[Connect](../../README.md#connect-to-windows-server) to the Windows Server instance via Remote Desktop and launch the Spirent TestCenter Application.
+[Connect](../../README.md#connect-to-windows-server) to the Windows Server instance via Remote Desktop and launch the TestCenter Application.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/install-testcenter.ps1
+++ b/install-testcenter.ps1
@@ -38,7 +38,7 @@ else
 }
 
 
-# Install Spirent TestCenter dependencies prior to SpirentTestCenter for a silent install
+# Install TestCenter dependencies prior to TestCenter for a silent install
 $stc_files_url = "http://stc-image-files.s3-website-us-east-1.amazonaws.com/win-install"
 
 Invoke-Download -FilePath "$Dir/chrome_installer.exe" -Url "http://dl.google.com/chrome/install/375.126/chrome_installer.exe"

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ resource "null_resource" "provisioner" {
     destination = "${var.dest_dir}/install-testcenter.ps1"
   }
 
-  # copy Spirent TestCenter installer
+  # copy TestCenter installer
   provisioner "file" {
     source      = var.stc_installer
     destination = "${var.dest_dir}/${basename(var.stc_installer)}"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent-Terraform-Modules/terraform-aws-stc-gui/8)
- - -
<!-- Reviewable:end -->
Replace "Spirent TestCenter" with "TestCenter" throughout human-readable text, update the support URL from support.spirent.com to the VIAVI support page, and update link text to match the new company name.